### PR TITLE
Update TF2 gamedata / plugin for version 8826692 (2024-04-18)

### DIFF
--- a/gamedata/edict_limiter.txt
+++ b/gamedata/edict_limiter.txt
@@ -199,7 +199,8 @@
                     // always try to alloc a new ent, regardless of FreeTime
                     "offset"    "1D6h"
                     "verify"    "\x77\x78"
-                    "patch"     "\x90\x90\x90\x90\x90\x90"
+                    "patch"     "\xEB\x78"
+                    "preserve"  "\x00\xFF"
                 }
                 "windows"
                 {

--- a/gamedata/edict_limiter.txt
+++ b/gamedata/edict_limiter.txt
@@ -127,7 +127,7 @@
                 "windows"
                 {
                     "signature" "sv"
-                    "read" "13"
+                    "read" "10"
                 }
             }
         }
@@ -158,14 +158,14 @@
             {
                 "library"   "engine"
                 "linux"     "@sv"
-                "windows"   "\x83\x3D\x2A\x2A\x2A\x2A\x02\x7D\x2A\x33\xC0\xC3"
+                "windows"   "\x83\x3D\x2A\x2A\x2A\x2A\x02\x7C\x2A\xB9\x2A\x2A\x2A\x2A"
             }
 
             // blocking facial flexes
             "CTFPlayer::SpeakWeaponFire"
             {
                 "library"   "server"
-                "windows"   "\x55\x8B\xEC\x8B\x45\x08\x81\xEC\x04\x01\x00\x00"
+                "windows"   "\x55\x8B\xEC\x8B\x15\x2A\x2A\x2A\x2A\x81\xEC\x04\x01\x00\x00"
                 "linux"     "@_ZN9CTFPlayer15SpeakWeaponFireEi"
             }
 
@@ -173,13 +173,18 @@
             "CTFPlayer::UpdateExpression"
             {
                 "library"   "server"
-                "windows"   "\x55\x8B\xEC\x81\xEC\x08\x01\x00\x00\x8D\x85\xF8\xFE\xFF\xFF\x56\x68\x04\x01\x00\x00"
                 "linux"     "@_ZN9CTFPlayer16UpdateExpressionEv"
+            }
+            "CTFPlayer::TFPlayerThink"
+            {
+                // UpdateExpression is inlined as of 8826692
+                "library"   "server"
+                "windows"   "\x53\x8B\xDC\x83\xEC\x08\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x04\x89\x6C\x24\x04\x8B\xEC\x81\xEC\x78\x02\x00\x00\x56\x57\x8B\xF9\x8B\x8F\xB0\x22\x00\x00"
             }
             "CTFPlayer::CreateFeignDeathRagdoll"
             {
                 "library"   "server"
-                "windows"   "\x55\x8B\xEC\x83\xEC\x10\x53\x8B\xD9\x56\x89\x5D\xFC"
+                "windows"   "\x55\x8B\xEC\x83\xEC\x40\x53\x56\x57\x8B\xF9\x8B\x8F\x24\x24\x00\x00"
                 "linux"     "@_ZN9CTFPlayer23CreateFeignDeathRagdollERK15CTakeDamageInfobbb"
             }
 
@@ -192,17 +197,41 @@
                 "linux"
                 {
                     // always try to alloc a new ent, regardless of FreeTime
-                    "offset"    "0224h"
-                    "verify"    "\x0F\x86\x2A\x2A\x2A\x2A"
+                    "offset"    "1D6h"
+                    "verify"    "\x77\x78"
                     "patch"     "\x90\x90\x90\x90\x90\x90"
                 }
                 "windows"
                 {
-                    "offset"    "0EEh"
+                    "offset"    "1D2h"
                     // ja
-                    "verify"    "\x77\x1B"
+                    "verify"    "\x77\x25"
                     // unconditional jmp
-                    "patch"     "\xEB\x1B"
+                    "patch"     "\xEB\x25"
+                    "preserve"  "\x00\xFF"
+                }
+            }
+            "CTFPlayer::TFPlayerThink::InlinedExpressionUpdateSkip"
+            {
+                "windows"
+                {
+                    "signature"     "CTFPlayer::TFPlayerThink"
+                    "offset"        "A40h"
+                    "verify"        "\x50\x6A\x02\x8B\xCF"
+                    // fix the stack (pop previously pushed 104h to ecx) then patch JMP to end of expression update (InlinedExpressionUpdateEnd-(InlinedExpressionUpdateSkip+6))
+                    "patch"         "\x59\xE9\x00\x00\x00\x00"
+                }
+            }
+            "CTFPlayer::TFPlayerThink::InlinedExpressionUpdateEnd"
+            {
+                "windows"
+                {
+                    // location after the inlined call to UpdateExpression (where the branches converge)
+                    // we only use this for getting the patch address and performing validation; it's not applied
+                    "signature"     "CTFPlayer::TFPlayerThink"
+                    "offset"        "BA9h"
+                    "verify"        "\x6A\x07\x8D"
+                    "patch"         "\x00"
                 }
             }
         }

--- a/scripting/EdictLimiter.sp
+++ b/scripting/EdictLimiter.sp
@@ -262,16 +262,43 @@ void DoGameData()
         }
         LogMessage("-> Set up [PRE]  SpeakWepFire detour");
 
-        Handle UpdateExpression = DHookCreateFromConf(hGameConf, "CTFPlayer::UpdateExpression");
-        if (!UpdateExpression)
+        if (isWindows)
         {
-            SetFailState("Couldn't create DHOOK for UpdateExpression");
+            // ::UpdateExpression was inlined on Windows in TF2 version 8826692
+            MemoryPatch InlinedExpressionUpdate = MemoryPatch.CreateFromConf(hGameConf, "CTFPlayer::TFPlayerThink::InlinedExpressionUpdateSkip");
+            MemoryPatch InlinedExpressionUpdateEnd = MemoryPatch.CreateFromConf(hGameConf, "CTFPlayer::TFPlayerThink::InlinedExpressionUpdateEnd");
+            
+            if (!InlinedExpressionUpdateEnd.Validate())
+            {
+                SetFailState("Failed to verify CTFPlayer::TFPlayerThink::InlinedExpressionUpdateEnd.");
+            }
+            else if (!InlinedExpressionUpdate.Validate())
+            {
+                SetFailState("Failed to verify CTFPlayer::TFPlayerThink::InlinedExpressionUpdateSkip.");
+            }
+            else if (!InlinedExpressionUpdate.Enable())
+            {
+                SetFailState("Failed to enable CTFPlayer::TFPlayerThink::InlinedExpressionUpdateSkip patch.");
+            }
+            else
+            {
+                int jumpLength = view_as<int>(InlinedExpressionUpdateEnd.Address) - (view_as<int>(InlinedExpressionUpdate.Address) + 6);
+                StoreToAddress(InlinedExpressionUpdate.Address + view_as<Address>(2), jumpLength, NumberType_Int32);
+                LogMessage("-> Enabled InlinedExpressionUpdateSkip (jump length %d)", jumpLength);
+            }
         }
-        if (!DHookEnableDetour(UpdateExpression, false /* pre */, CTFPlayer__UpdateExpression_Pre))
+        else
         {
-            SetFailState("Couldn't set up detour for UpdateExpression");
+            Handle UpdateExpression = DHookCreateFromConf(hGameConf, "CTFPlayer::UpdateExpression");
+            if (UpdateExpression)
+            {
+                if (!DHookEnableDetour(UpdateExpression, false /* pre */, CTFPlayer__UpdateExpression_Pre))
+                {
+                    SetFailState("Couldn't set up detour for UpdateExpression");
+                }
+                LogMessage("-> Set up [PRE]  UpdateExpression detour");
+            }
         }
-        LogMessage("-> Set up [PRE]  UpdateExpression detour");
     }
 
     delete hGameConf;


### PR DESCRIPTION
Brings ~~Windows~~ gamedata up to date.

Important breaking change: `CTFPlayer::UpdateExpression` has been inlined on Windows.  It only gets called on `CTFPlayer::TFPlayerThink`, so I've modified the plugin to patch the code so it fixes the stack and jumps to the end of the inlined code to mimic the previous supercede behavior.

The jump offset is handled in code after validating that both locations have the bytes that it's expecting.

Windows bits have been tested and no crashes have been observed.

that said, suffer